### PR TITLE
smote-variants 1.0.1 (rebuild - scikit-learn 1.7.0 compatibility)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,9 @@ requirements:
     - pandas
     - mkl-devel  {{ mkl }}           # [blas_impl == 'mkl']
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
+    # https://github.com/AnacondaRecipes/metric-learn-feedstock/blob/main/recipe/meta.yaml#L28
+    # Can`t use version higher than 1.3.2
+    - scikit-learn >=0.21.3,<1.3.2
     - metric-learn
     - seaborn
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-do-not-require-statistic-and-mkl.patch
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   # On s390x tensorflow  does not exist (perhaps a typo or a missing channel).
   skip: True  # [s390x]


### PR DESCRIPTION
The smote-variants pkg is uninstalable because of the scikit-learn 1.7.0 release.